### PR TITLE
Resolved unsupported device issue with dependency change

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -54,5 +54,5 @@ dependencies {
     testCompile 'org.robolectric:shadows-httpclient:3.2.2'
     testCompile 'org.assertj:assertj-core:3.6.2'
     testCompile 'org.powermock:powermock-api-mockito:1.6.6'
-    compile 'org.apache.directory.studio:org.apache.commons.io:2.4'
+    compile 'commons-io:commons-io:2.4'
 }


### PR DESCRIPTION
I removed the `org.apache.directory.studio:org.apache.commons.io:2.4` dependency and used `commons-io:commons-io:2.4` in lib module. This changes fixed problem in my app. I think it should work great now ✨ #49 

Check this [link](https://stackoverflow.com/a/32749726/1292557) and this [link](https://github.com/nestlabs/android-sdk/issues/5)

Closes #49 