### PR TITLE
Returns pending user error

### DIFF
--- a/lib/src/main/java/com/ibm/bluemix/appid/android/internal/tokenmanager/TokenManager.java
+++ b/lib/src/main/java/com/ibm/bluemix/appid/android/internal/tokenmanager/TokenManager.java
@@ -64,9 +64,9 @@ public class TokenManager {
 	private static final String REFRESH_TOKEN = "refresh_token";
 	private static final String GRANT_TYPE_REFRESH = "refresh_token";
 	private final static String APPID_ACCESS_TOKEN = "appid_access_token";
-    private final static String ERROR_DESCRIPTION= "error_description";
-    private final static String ERROR_CODE= "error";
-    private final static String INVALID_GRANT= "invalid_grant";
+	private final static String ERROR_DESCRIPTION= "error_description";
+	private final static String ERROR= "error";
+	private final static String INVALID_GRANT= "invalid_grant";
 
 	public TokenManager (OAuthManager oAuthManager) {
 		this.appId = oAuthManager.getAppId();
@@ -88,7 +88,7 @@ public class TokenManager {
 	}
 
 	//for testing purpose
-    AppIDRequest createAppIDRequest(String url, String method) {
+	AppIDRequest createAppIDRequest(String url, String method) {
 		return new AppIDRequest(url, method);
 	}
 
@@ -113,19 +113,17 @@ public class TokenManager {
 				try {
 					if (response.getStatus() == 400) {
 						JSONObject responseJSON = new JSONObject(response.getResponseText());
-						if (INVALID_GRANT.equals(responseJSON.getString(ERROR_CODE))) {
-							String errorDescription = responseJSON.getString(ERROR_DESCRIPTION);
-							listener.onAuthorizationFailure(new AuthorizationException(errorDescription));
+						if (INVALID_GRANT.equals(responseJSON.getString(ERROR))) {
+							listener.onAuthorizationFailure(new AuthorizationException(responseJSON.getString(ERROR_DESCRIPTION)));
 							return;
 						}
 					} else if (response.getStatus() == 403) {
 						JSONObject responseJSON = new JSONObject(response.getResponseText());
-						String errorDescription = responseJSON.getString(ERROR_DESCRIPTION);
-						listener.onAuthorizationFailure(new AuthorizationException(errorDescription));
+						listener.onAuthorizationFailure(new AuthorizationException(responseJSON.getString(ERROR_DESCRIPTION)));
 						return;
 					}
 
-                    listener.onAuthorizationFailure(new AuthorizationException("Failed to retrieve tokens"));
+					listener.onAuthorizationFailure(new AuthorizationException("Failed to retrieve tokens"));
 				} catch (Exception e) {
 					logger.error("Failed to retrieve tokens from authorization server", t);
 					listener.onAuthorizationFailure(new AuthorizationException("Failed to retrieve tokens"));
@@ -143,9 +141,9 @@ public class TokenManager {
 		logger.debug("obtainTokensRoP");
 
 		HashMap<String, String> formParams = new HashMap<>();
-        formParams.put(USERNAME, username);
-        formParams.put(PASSWORD, password);
-        formParams.put(GRANT_TYPE, GRANT_TYPE_PASSWORD);
+		formParams.put(USERNAME, username);
+		formParams.put(PASSWORD, password);
+		formParams.put(GRANT_TYPE, GRANT_TYPE_PASSWORD);
 		if (accessTokenString != null) {
 			formParams.put(APPID_ACCESS_TOKEN, accessTokenString);
 		}

--- a/lib/src/main/java/com/ibm/bluemix/appid/android/internal/tokenmanager/TokenManager.java
+++ b/lib/src/main/java/com/ibm/bluemix/appid/android/internal/tokenmanager/TokenManager.java
@@ -109,16 +109,22 @@ public class TokenManager {
 			@Override
 			public void onFailure (Response response, Throwable t, JSONObject extendedInfo) {
 				logger.error("Failed to retrieve tokens from authorization server", t);
-				String errorDescription = "";
+
 				try {
 					if (response.getStatus() == 400) {
-                        JSONObject responseJSON = new JSONObject(response.getResponseText());
-                        if (INVALID_GRANT.equals(responseJSON.getString(ERROR_CODE))) {
-                            errorDescription = responseJSON.getString(ERROR_DESCRIPTION);
-                            listener.onAuthorizationFailure(new AuthorizationException(errorDescription));
-                            return;
-                        }
-                    }
+						JSONObject responseJSON = new JSONObject(response.getResponseText());
+						if (INVALID_GRANT.equals(responseJSON.getString(ERROR_CODE))) {
+							String errorDescription = responseJSON.getString(ERROR_DESCRIPTION);
+							listener.onAuthorizationFailure(new AuthorizationException(errorDescription));
+							return;
+						}
+					} else if (response.getStatus() == 403) {
+						JSONObject responseJSON = new JSONObject(response.getResponseText());
+						String errorDescription = responseJSON.getString(ERROR_DESCRIPTION);
+						listener.onAuthorizationFailure(new AuthorizationException(errorDescription));
+						return;
+					}
+
                     listener.onAuthorizationFailure(new AuthorizationException("Failed to retrieve tokens"));
 				} catch (Exception e) {
 					logger.error("Failed to retrieve tokens from authorization server", t);

--- a/lib/src/test/java/com/ibm/bluemix/appid/android/internal/tokenmanager/TokenManager_Test.java
+++ b/lib/src/test/java/com/ibm/bluemix/appid/android/internal/tokenmanager/TokenManager_Test.java
@@ -219,9 +219,7 @@ public class TokenManager_Test {
     }
 
     @Test
-    public void obtainTokensRop_failure_400() {
-        final String testDescription = "test description error123";
-        testReponse = createResponse("{\"error\": \"invalid_grant\" , \"error_description\": \"" + testDescription + "\" }", 400);
+    public void obtainTokensRop_failure() {
 
         doAnswer(new Answer() {
             @Override
@@ -233,29 +231,15 @@ public class TokenManager_Test {
             }
         }).when(stubRequest).send(any(Map.class), any(ResponseListener.class));
 
-        spyTokenManager.obtainTokensRoP(username, password, null, getExpectedFailureListener(testDescription));
+        // test 400
+        final String testDescription400 = "test description error123";
+        testReponse = createResponse("{\"error\": \"invalid_grant\" , \"error_description\": \"" + testDescription400 + "\" }", 400);
+        spyTokenManager.obtainTokensRoP(username, password, null, getExpectedFailureListener(testDescription400));
 
-        //test the exception parsing
-        testReponse = null;
-        spyTokenManager.obtainTokensRoP(username, password, null, getExpectedFailureListener("Failed to retrieve tokens"));
-    }
-
-    @Test
-    public void obtainTokensRop_failure_403() {
-        final String testDescription = "Pending User Verification";
-        testReponse = createResponse("{\"error_code\": \"FORBIDDEN\" , \"error_description\": \"" + testDescription + "\" }", 403);
-
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Object[] args = invocation.getArguments();
-                ResponseListener responseListener = (ResponseListener) args[1];
-                responseListener.onFailure(testReponse, null, null);
-                return null;
-            }
-        }).when(stubRequest).send(any(Map.class), any(ResponseListener.class));
-
-        spyTokenManager.obtainTokensRoP(username, password, null, getExpectedFailureListener(testDescription));
+        // test 403
+        final String testDescription403 = "Pending User Verification";
+        testReponse = createResponse("{\"error_code\": \"FORBIDDEN\" , \"error_description\": \"" + testDescription403 + "\" }", 403);
+        spyTokenManager.obtainTokensRoP(username, password, null, getExpectedFailureListener(testDescription403));
 
         //test the exception parsing
         testReponse = null;

--- a/lib/src/test/java/com/ibm/bluemix/appid/android/internal/tokenmanager/TokenManager_Test.java
+++ b/lib/src/test/java/com/ibm/bluemix/appid/android/internal/tokenmanager/TokenManager_Test.java
@@ -219,7 +219,7 @@ public class TokenManager_Test {
     }
 
     @Test
-    public void obtainTokensRop_failure() {
+    public void obtainTokensRop_failure_400() {
         final String testDescription = "test description error123";
         testReponse = createResponse("{\"error\": \"invalid_grant\" , \"error_description\": \"" + testDescription + "\" }", 400);
 
@@ -229,6 +229,28 @@ public class TokenManager_Test {
                 Object[] args = invocation.getArguments();
                 ResponseListener responseListener = (ResponseListener) args[1];
                 responseListener.onFailure(testReponse ,null, null);
+                return null;
+            }
+        }).when(stubRequest).send(any(Map.class), any(ResponseListener.class));
+
+        spyTokenManager.obtainTokensRoP(username, password, null, getExpectedFailureListener(testDescription));
+
+        //test the exception parsing
+        testReponse = null;
+        spyTokenManager.obtainTokensRoP(username, password, null, getExpectedFailureListener("Failed to retrieve tokens"));
+    }
+
+    @Test
+    public void obtainTokensRop_failure_403() {
+        final String testDescription = "Pending User Verification";
+        testReponse = createResponse("{\"error_code\": \"FORBIDDEN\" , \"error_description\": \"" + testDescription + "\" }", 403);
+
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                ResponseListener responseListener = (ResponseListener) args[1];
+                responseListener.onFailure(testReponse, null, null);
                 return null;
             }
         }).when(stubRequest).send(any(Map.class), any(ResponseListener.class));


### PR DESCRIPTION
Currently, the sdk returns "Token retrieval failed" by default; however, the client application may want to initiate different flows depending on the status of a cloud directory user.

When a request fails due to incorrect credentials or the user is pending verification, this message is now passed to the client. Additionally, our error description fields should be public for ease of consumption.